### PR TITLE
Fix Open in Image MetaHub saved path

### DIFF
--- a/js/metahub_save_cta.js
+++ b/js/metahub_save_cta.js
@@ -26,6 +26,8 @@ function openUrl(url) {
 
 function getSavedPaths(message) {
     const candidates = [
+        message?.imagemetahub_files,
+        message?.ui?.imagemetahub_files,
         message?.imagemetahub?.files,
         message?.ui?.imagemetahub?.files,
     ];

--- a/metadata_utils.py
+++ b/metadata_utils.py
@@ -3,7 +3,7 @@ Compatibility shim for MetaHub Save Node metadata helpers.
 
 The implementation is kept in metadata_utils_impl.py; this module exposes the
 same public API expected by the save nodes while pinning the published node
-version to 1.1.6.
+version to 1.1.7.
 """
 
 try:
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import metadata_utils_impl as _impl
 
-METAHUB_SAVE_NODE_VERSION = "1.1.6"
+METAHUB_SAVE_NODE_VERSION = "1.1.7"
 _impl.METAHUB_SAVE_NODE_VERSION = METAHUB_SAVE_NODE_VERSION
 
 for _name in dir(_impl):

--- a/metadata_utils_impl.py
+++ b/metadata_utils_impl.py
@@ -14,7 +14,7 @@ from xml.sax.saxutils import escape as xml_escape
 import numpy as np
 from PIL import Image, PngImagePlugin
 
-METAHUB_SAVE_NODE_VERSION = "1.1.6"
+METAHUB_SAVE_NODE_VERSION = "1.1.7"
 
 try:
     import piexif
@@ -1375,8 +1375,8 @@ def build_ui_preview(saved_paths: List[Path], output_base: Path) -> dict:
     return {
         "ui": {
             "images": ui_images,
-            "imagemetahub": {
-                "files": [str(file_path.resolve()) for file_path in saved_paths]
-            }
+            "imagemetahub_files": [
+                str(file_path.resolve()) for file_path in saved_paths
+            ],
         }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "imagemetahub-comfyui-save"
 description = "Official companion node for Image MetaHub. Saves A1111/Civitai-compatible parameters plus extended Image MetaHub metadata (workflow JSON, SHA256 model hashes, VRAM peak/total, GPU device, generation time, and steps/sec) for reproducibility and benchmarking."
-version = "1.1.6"
+version = "1.1.7"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -55,7 +55,7 @@ def test_build_ui_preview_exposes_absolute_paths_for_image_metahub(tmp_path):
         "subfolder": "session",
         "type": "output",
     }]
-    assert result["ui"]["imagemetahub"]["files"] == [str(saved_path.resolve())]
+    assert result["ui"]["imagemetahub_files"] == [str(saved_path.resolve())]
 
 
 def _save_simple_png(path: Path) -> None:
@@ -334,7 +334,7 @@ def test_extract_workflow_attribution_from_node_properties():
 
     assert attribution["token"] == "imhcrt_br_creator_workflow_v1_random"
     assert attribution["source"] == "metahub_save_node"
-    assert attribution["node_version"] == "1.1.6"
+    assert attribution["node_version"] == "1.1.7"
 
 
 def test_build_imh_metadata_includes_attribution_without_a1111_parameters():


### PR DESCRIPTION
## What changed

- Flatten the saved-path UI payload to `imagemetahub_files` so ComfyUI preserves the absolute file paths.
- Update the frontend CTA to read the flattened payload while retaining compatibility with the previous shape.
- Bump the node version from `1.1.6` to `1.1.7` in the package and embedded metadata version fields.
- Update focused tests for the new payload and version.

## Why

ComfyUI serialized the nested payload as `imagemetahub: ["files"]`, discarding the actual paths. As a result, the node never recorded the generated image path and “Open in Image MetaHub” incorrectly asked the user to generate an image first.

## Impact

After generating an image, the button can retain its absolute saved path and open that image through the Image MetaHub deep link.

## Validation

- `node --check js/metahub_save_cta.js`
- `pytest -q tests/test_metadata_utils.py -k "build_ui_preview_exposes_absolute_paths_for_image_metahub or extract_workflow_attribution_from_node_properties"` — 2 passed
- `git diff --check`