### PR TITLE
Add MetaHub Save 3D Model node

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MetaHub Save Image - ComfyUI Custom Node
+# MetaHub Save - ComfyUI Custom Nodes
 [![Official Companion](https://img.shields.io/badge/Official%20companion-Image%20MetaHub-2b6cb0)](https://github.com/LuqP2/Image-MetaHub) [![Comfy Registry](https://img.shields.io/badge/Comfy-Registry-blue)](https://registry.comfy.org/publishers/image-metahub/nodes/imagemetahub-comfyui-save)
 
 
@@ -7,13 +7,14 @@ https://registry.comfy.org/publishers/image-metahub/nodes/imagemetahub-comfyui-s
 
 Official companion node for [Image MetaHub](https://github.com/LuqP2/Image-MetaHub). 
 
-Advanced image saving node for ComfyUI with dual metadata support.
+Advanced image and 3D model saving nodes for ComfyUI with complete Image MetaHub metadata support.
 
 ## Features
 
 - **Auto-Extraction** - Detects sampler params, prompts, model/VAE, and LoRAs directly from your workflow
 - **Performance Metrics** - Auto-tracks GPU usage, VRAM peak, generation time, and software versions
 - **Multi-Format** - PNG, JPEG, and WebP with metadata injection
+- **3D Models** - Saves MESH as GLB and preserves File3D GLB, GLTF, OBJ, FBX, or STL inputs
 - **Filename Patterns** - Placeholder-based filenames with sanitization
 - **A1111/Civitai Compatible** - Saves metadata in tEXt chunk ("parameters") recognized by Automatic1111, Civitai, and most SD tools
 - **Image MetaHub Compatible** - Saves extended metadata in iTXt chunk ("imagemetahub_data") with full workflow JSON
@@ -96,6 +97,19 @@ If a workflow uses custom nodes that the extractor cannot understand yet, the
 image is still saved and the metadata is marked as `partial`. In that case,
 connect only the missing override sockets you care about, such as `positive`,
 `seed`, or `model_name`.
+
+### Saving 3D Models
+
+1. Add **MetaHub Save 3D Model** from `3d/save`.
+2. Connect a ComfyUI `MESH` or File3D GLB/GLTF/OBJ/FBX/STL output.
+3. Generate. MESH inputs are written as GLB; File3D inputs keep their format.
+
+The node returns `ui.3d` for ComfyUI's native 3D preview. Every supported
+format receives `<model>.<ext>.imagemetahub.json`; GLB also embeds the same
+payload at `asset.extras.imagemetahub_data`. Both include the complete workflow,
+prompt API, generation parameters, telemetry, tags, notes, project data, and
+available geometry information. ComfyUI's `--disable-metadata` disables both
+the sidecar and embedded payload.
 
 ### MetaHub Input Bridge
 

--- a/__init__.py
+++ b/__init__.py
@@ -7,11 +7,13 @@ try:
     from .metahub_input_node import MetaHubInputNode
     from .metahub_save_node import MetaHubSaveImage, MetaHubSaveNode
     from .metahub_save_video_node import MetaHubSaveVideoNode
+    from .metahub_save_3d_node import MetaHubSave3DModel
     from .timer_node import MetaHubTimerNode
 except ImportError:
     from metahub_input_node import MetaHubInputNode
     from metahub_save_node import MetaHubSaveImage, MetaHubSaveNode
     from metahub_save_video_node import MetaHubSaveVideoNode
+    from metahub_save_3d_node import MetaHubSave3DModel
     from timer_node import MetaHubTimerNode
 
 NODE_CLASS_MAPPINGS = {
@@ -19,7 +21,8 @@ NODE_CLASS_MAPPINGS = {
     "MetaHubSaveImage": MetaHubSaveImage,
     "MetaHubSaveNode": MetaHubSaveNode,
     "MetaHubSaveVideoNode": MetaHubSaveVideoNode,
-    "MetaHubTimerNode": MetaHubTimerNode
+    "MetaHubTimerNode": MetaHubTimerNode,
+    "MetaHubSave3DModel": MetaHubSave3DModel
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -27,7 +30,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "MetaHubSaveImage": "MetaHub Save Image",
     "MetaHubSaveNode": "MetaHub Save Image Advanced",
     "MetaHubSaveVideoNode": "MetaHub Save Video",
-    "MetaHubTimerNode": "MetaHub Timer"
+    "MetaHubTimerNode": "MetaHub Timer",
+    "MetaHubSave3DModel": "MetaHub Save 3D Model"
 }
 
 WEB_DIRECTORY = "./js"

--- a/js/metahub_save_cta.js
+++ b/js/metahub_save_cta.js
@@ -14,6 +14,66 @@ const CTA_WIDGET_NAMES = new Set([
     "Open in Image MetaHub",
     "Get Image MetaHub",
 ]);
+const METAHUB_SAVE_3D_CLASS = "MetaHubSave3DModel";
+const COMFY_SAVE_3D_EXTENSION = "Comfy.SaveGLB";
+
+function addNative3DPreviewInput(nodeData) {
+    if (nodeData.name !== METAHUB_SAVE_3D_CLASS) {
+        return;
+    }
+
+    nodeData.input ??= {};
+    nodeData.input.required ??= {};
+    nodeData.input.required.image = ["PREVIEW_3D"];
+}
+
+async function initializeNative3DPreview(node) {
+    if (
+        node.comfyClass !== METAHUB_SAVE_3D_CLASS ||
+        node.__imageMetaHubNative3DPreviewInitialized
+    ) {
+        return;
+    }
+
+    const save3DExtension = app.extensions?.find(
+        (extension) => extension.name === COMFY_SAVE_3D_EXTENSION
+    );
+    if (typeof save3DExtension?.nodeCreated !== "function") {
+        return;
+    }
+
+    const nodeConstructor = node.constructor;
+    const ownConstructorDescriptor = Object.getOwnPropertyDescriptor(node, "constructor");
+    const saveGLBConstructor = new Proxy(nodeConstructor, {
+        get(target, property, receiver) {
+            if (property === "comfyClass") {
+                return "SaveGLB";
+            }
+            return Reflect.get(target, property, receiver);
+        },
+    });
+    node.__imageMetaHubNative3DPreviewInitialized = true;
+
+    try {
+        // ComfyUI's native viewer is intentionally restricted to SaveGLB.
+        // Reuse its initializer with the real MetaHub node instance, then
+        // restore the class before workflow serialization can observe it.
+        Object.defineProperty(node, "constructor", {
+            configurable: true,
+            value: saveGLBConstructor,
+        });
+        await save3DExtension.nodeCreated(node, app);
+    } catch (error) {
+        node.__imageMetaHubNative3DPreviewInitialized = false;
+        console.warn("Image MetaHub: native 3D preview initialization failed", error);
+    } finally {
+        if (ownConstructorDescriptor) {
+            Object.defineProperty(node, "constructor", ownConstructorDescriptor);
+        } else {
+            delete node.constructor;
+        }
+    }
+}
 
 function buildDeepLink(node) {
     const savedPath = node.__imageMetaHubLastSavedPath;
@@ -185,6 +245,8 @@ app.registerExtension({
             return;
         }
 
+        addNative3DPreviewInput(nodeData);
+
         const originalOnExecuted = nodeType.prototype.onExecuted;
         nodeType.prototype.onExecuted = function (message) {
             originalOnExecuted?.apply(this, arguments);
@@ -193,6 +255,13 @@ app.registerExtension({
     },
 
     async nodeCreated(node) {
+        await initializeNative3DPreview(node);
         syncMetaHubCTA(node);
+        if (node.comfyClass === METAHUB_SAVE_3D_CLASS) {
+            node.setSize?.([
+                Math.max(node.size?.[0] ?? 0, 400),
+                Math.max(node.size?.[1] ?? 0, 700),
+            ]);
+        }
     },
 });

--- a/js/metahub_save_cta.js
+++ b/js/metahub_save_cta.js
@@ -4,6 +4,7 @@ const METAHUB_SAVE_NODE_CLASSES = new Set([
     "MetaHubSaveImage",
     "MetaHubSaveNode",
     "MetaHubSaveVideoNode",
+    "MetaHubSave3DModel",
 ]);
 
 const IMAGE_METAHUB_URL = "https://www.imagemetahub.com/";

--- a/metadata_utils.py
+++ b/metadata_utils.py
@@ -3,7 +3,7 @@ Compatibility shim for MetaHub Save Node metadata helpers.
 
 The implementation is kept in metadata_utils_impl.py; this module exposes the
 same public API expected by the save nodes while pinning the published node
-version to 1.1.9.
+version to 1.2.0.
 """
 
 try:
@@ -11,7 +11,7 @@ try:
 except ImportError:
     import metadata_utils_impl as _impl
 
-METAHUB_SAVE_NODE_VERSION = "1.1.9"
+METAHUB_SAVE_NODE_VERSION = "1.2.0"
 _impl.METAHUB_SAVE_NODE_VERSION = METAHUB_SAVE_NODE_VERSION
 
 for _name in dir(_impl):

--- a/metadata_utils_impl.py
+++ b/metadata_utils_impl.py
@@ -14,7 +14,7 @@ from xml.sax.saxutils import escape as xml_escape
 import numpy as np
 from PIL import Image, PngImagePlugin
 
-METAHUB_SAVE_NODE_VERSION = "1.1.9"
+METAHUB_SAVE_NODE_VERSION = "1.2.0"
 
 try:
     import piexif

--- a/metadata_utils_impl.py
+++ b/metadata_utils_impl.py
@@ -536,7 +536,7 @@ def extract_workflow_attribution(workflow_json: dict, save_node_id: Optional[str
                 continue
             candidates = [node]
             break
-        if node.get("type") in ("MetaHubSaveImage", "MetaHubSaveNode", "MetaHubSaveVideoNode") or node.get("class_type") in ("MetaHubSaveImage", "MetaHubSaveNode", "MetaHubSaveVideoNode"):
+        if node.get("type") in ("MetaHubSaveImage", "MetaHubSaveNode", "MetaHubSaveVideoNode", "MetaHubSave3DModel") or node.get("class_type") in ("MetaHubSaveImage", "MetaHubSaveNode", "MetaHubSaveVideoNode", "MetaHubSave3DModel"):
             candidates.append(node)
 
     if len(candidates) != 1:

--- a/metahub_save_3d_node.py
+++ b/metahub_save_3d_node.py
@@ -189,7 +189,8 @@ def _write_glb(
         gltf["asset"]["extras"] = {"imagemetahub_data": metadata}
 
     materials: list[dict] = []
-    if texture_bytes and uv_array is not None:
+    has_embedded_texture = bool(texture_bytes and uv_array is not None)
+    if has_embedded_texture:
         texture_view = append_buffer(texture_bytes)
         gltf["images"] = [{"bufferView": texture_view, "mimeType": "image/png"}]
         gltf["samplers"] = [{"magFilter": 9729, "minFilter": 9729, "wrapS": 33071, "wrapT": 33071}]
@@ -231,7 +232,7 @@ def _write_glb(
         "vertexCount": int(len(positions)),
         "faceCount": int(len(indices) // 3),
         "materialCount": len(materials),
-        "hasTextures": bool(texture_bytes),
+        "hasTextures": has_embedded_texture,
         "bounds": {"min": positions.min(axis=0).tolist(), "max": positions.max(axis=0).tolist()},
     }
 

--- a/metahub_save_3d_node.py
+++ b/metahub_save_3d_node.py
@@ -1,0 +1,469 @@
+"""Image MetaHub 3D save node for ComfyUI.
+
+The node deliberately uses the legacy node registration surface so the package
+continues to load on older ComfyUI releases.  The wildcard input accepts both
+the current ``MESH`` value and the newer File3D wrappers.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+import time
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional, Tuple
+
+import numpy as np
+from PIL import Image
+
+try:
+    import folder_paths
+except ImportError:  # pragma: no cover - exercised only outside ComfyUI
+    folder_paths = None
+
+try:
+    from comfy.cli_args import args
+except ImportError:  # pragma: no cover - test/legacy fallback
+    class _Args:
+        disable_metadata = False
+
+    args = _Args()
+
+try:
+    from . import metadata_utils as utils
+    from .workflow_extractor import WorkflowExtractor
+except ImportError:
+    import metadata_utils as utils
+    from workflow_extractor import WorkflowExtractor
+
+
+class AnyType(str):
+    """ComfyUI V1 wildcard socket compatible with all upstream 3D types."""
+
+    def __ne__(self, _value: object) -> bool:
+        return False
+
+
+ANY_3D = AnyType("*")
+SUPPORTED_FORMATS = {"glb", "gltf", "obj", "fbx", "stl"}
+
+
+def _tensor_numpy(value: Any, dtype: np.dtype) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach()
+    if hasattr(value, "cpu"):
+        value = value.cpu()
+    if hasattr(value, "numpy"):
+        value = value.numpy()
+    return np.asarray(value, dtype=dtype)
+
+
+def _mesh_batch_item(mesh: Any, index: int) -> Tuple[Any, Any, Any, Any, Any]:
+    vertex_count = None
+    face_count = None
+    if getattr(mesh, "vertex_counts", None) is not None:
+        vertex_count = int(mesh.vertex_counts[index].item())
+        face_count = int(mesh.face_counts[index].item())
+
+    vertices = mesh.vertices[index]
+    faces = mesh.faces[index]
+    colors = getattr(mesh, "vertex_colors", None)
+    uvs = getattr(mesh, "uvs", None)
+    texture = getattr(mesh, "texture", None)
+
+    if vertex_count is not None:
+        vertices = vertices[:vertex_count]
+        faces = faces[:face_count]
+        if colors is not None:
+            colors = colors[index, :vertex_count]
+        if uvs is not None:
+            uvs = uvs[index, :vertex_count]
+    else:
+        colors = colors[index] if colors is not None else None
+        uvs = uvs[index] if uvs is not None else None
+
+    texture = texture[index] if texture is not None else None
+    return vertices, faces, colors, uvs, texture
+
+
+def _pad4(data: bytes, fill: bytes = b"\x00") -> bytes:
+    return data + fill * ((4 - len(data) % 4) % 4)
+
+
+def _write_glb(
+    output_path: Path,
+    vertices: Any,
+    faces: Any,
+    metadata: Optional[Dict[str, Any]],
+    *,
+    vertex_colors: Any = None,
+    uvs: Any = None,
+    texture: Any = None,
+    unlit: bool = False,
+) -> Dict[str, Any]:
+    positions = _tensor_numpy(vertices, np.float32).reshape(-1, 3)
+    indices_signed = _tensor_numpy(faces, np.int64).reshape(-1, 3)
+    if positions.size == 0 or indices_signed.size == 0:
+        raise ValueError("Cannot save an empty 3D mesh")
+    if indices_signed.min() < 0 or indices_signed.max() >= len(positions):
+        raise ValueError("Mesh contains an out-of-range face index")
+
+    indices = indices_signed.astype(np.uint32, copy=False).reshape(-1)
+    uv_array = _tensor_numpy(uvs, np.float32).reshape(-1, 2) if uvs is not None else None
+    color_array = _tensor_numpy(vertex_colors, np.float32) if vertex_colors is not None else None
+    if color_array is not None:
+        color_array = np.clip(color_array.reshape(len(positions), -1), 0.0, 1.0)
+        if color_array.shape[1] not in (3, 4):
+            color_array = None
+    if uv_array is not None and len(uv_array) != len(positions):
+        uv_array = None
+
+    texture_bytes = b""
+    if texture is not None:
+        texture_array = _tensor_numpy(texture, np.float32)
+        texture_array = np.clip(texture_array * 255.0, 0, 255).astype(np.uint8)
+        if texture_array.ndim == 3 and texture_array.shape[-1] in (3, 4):
+            buffer = BytesIO()
+            Image.fromarray(texture_array, mode="RGBA" if texture_array.shape[-1] == 4 else "RGB").save(buffer, "PNG")
+            texture_bytes = buffer.getvalue()
+
+    chunks: list[bytes] = []
+    buffer_views: list[dict] = []
+    accessors: list[dict] = []
+
+    def append_buffer(data: bytes, target: Optional[int] = None) -> int:
+        offset = sum(len(chunk) for chunk in chunks)
+        padded = _pad4(data)
+        chunks.append(padded)
+        view: dict = {"buffer": 0, "byteOffset": offset, "byteLength": len(data)}
+        if target is not None:
+            view["target"] = target
+        buffer_views.append(view)
+        return len(buffer_views) - 1
+
+    position_view = append_buffer(positions.tobytes(), 34962)
+    accessors.append({
+        "bufferView": position_view,
+        "componentType": 5126,
+        "count": len(positions),
+        "type": "VEC3",
+        "min": positions.min(axis=0).tolist(),
+        "max": positions.max(axis=0).tolist(),
+    })
+    index_view = append_buffer(indices.tobytes(), 34963)
+    accessors.append({
+        "bufferView": index_view,
+        "componentType": 5125,
+        "count": len(indices),
+        "type": "SCALAR",
+    })
+    attributes: dict = {"POSITION": 0}
+
+    if uv_array is not None:
+        uv_view = append_buffer(uv_array.tobytes(), 34962)
+        accessors.append({"bufferView": uv_view, "componentType": 5126, "count": len(uv_array), "type": "VEC2"})
+        attributes["TEXCOORD_0"] = len(accessors) - 1
+    if color_array is not None:
+        color_view = append_buffer(color_array.astype(np.float32).tobytes(), 34962)
+        accessors.append({
+            "bufferView": color_view,
+            "componentType": 5126,
+            "count": len(color_array),
+            "type": "VEC4" if color_array.shape[1] == 4 else "VEC3",
+        })
+        attributes["COLOR_0"] = len(accessors) - 1
+
+    primitive: dict = {"attributes": attributes, "indices": 1, "mode": 4}
+    gltf: dict = {
+        "asset": {"version": "2.0", "generator": "Image MetaHub ComfyUI Save"},
+        "buffers": [],
+        "bufferViews": buffer_views,
+        "accessors": accessors,
+        "meshes": [{"primitives": [primitive]}],
+        "nodes": [{"mesh": 0}],
+        "scenes": [{"nodes": [0]}],
+        "scene": 0,
+    }
+    if metadata:
+        gltf["asset"]["extras"] = {"imagemetahub_data": metadata}
+
+    materials: list[dict] = []
+    if texture_bytes and uv_array is not None:
+        texture_view = append_buffer(texture_bytes)
+        gltf["images"] = [{"bufferView": texture_view, "mimeType": "image/png"}]
+        gltf["samplers"] = [{"magFilter": 9729, "minFilter": 9729, "wrapS": 33071, "wrapT": 33071}]
+        gltf["textures"] = [{"source": 0, "sampler": 0}]
+        materials.append({
+            "pbrMetallicRoughness": {
+                "baseColorTexture": {"index": 0, "texCoord": 0},
+                "metallicFactor": 0.0,
+                "roughnessFactor": 1.0,
+            },
+            "doubleSided": True,
+        })
+        primitive["material"] = 0
+    elif unlit:
+        materials.append({
+            "pbrMetallicRoughness": {"baseColorFactor": [1, 1, 1, 1], "metallicFactor": 0.0, "roughnessFactor": 1.0},
+            "extensions": {"KHR_materials_unlit": {}},
+            "doubleSided": True,
+        })
+        gltf["extensionsUsed"] = ["KHR_materials_unlit"]
+        primitive["material"] = 0
+    if materials:
+        gltf["materials"] = materials
+
+    binary = b"".join(chunks)
+    gltf["buffers"] = [{"byteLength": len(binary)}]
+    json_bytes = _pad4(json.dumps(gltf, ensure_ascii=False, separators=(",", ":")).encode("utf-8"), b" ")
+    total_length = 12 + 8 + len(json_bytes) + 8 + len(binary)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("wb") as handle:
+        handle.write(struct.pack("<4sII", b"glTF", 2, total_length))
+        handle.write(struct.pack("<II", len(json_bytes), 0x4E4F534A))
+        handle.write(json_bytes)
+        handle.write(struct.pack("<II", len(binary), 0x004E4942))
+        handle.write(binary)
+
+    return {
+        "format": "glb",
+        "vertexCount": int(len(positions)),
+        "faceCount": int(len(indices) // 3),
+        "materialCount": len(materials),
+        "hasTextures": bool(texture_bytes),
+        "bounds": {"min": positions.min(axis=0).tolist(), "max": positions.max(axis=0).tolist()},
+    }
+
+
+def _inject_glb_metadata(file_path: Path, metadata: Dict[str, Any]) -> bool:
+    try:
+        data = file_path.read_bytes()
+        if len(data) < 20 or data[:4] != b"glTF":
+            return False
+        _magic, version, _total = struct.unpack_from("<4sII", data, 0)
+        if version != 2:
+            return False
+        json_length, json_type = struct.unpack_from("<II", data, 12)
+        if json_type != 0x4E4F534A or 20 + json_length > len(data):
+            return False
+        document = json.loads(data[20:20 + json_length].rstrip(b" \x00").decode("utf-8"))
+        asset = document.setdefault("asset", {"version": "2.0"})
+        extras = asset.setdefault("extras", {})
+        if not isinstance(extras, dict):
+            extras = {}
+            asset["extras"] = extras
+        extras["imagemetahub_data"] = metadata
+        new_json = _pad4(json.dumps(document, ensure_ascii=False, separators=(",", ":")).encode("utf-8"), b" ")
+        remaining = data[20 + json_length:]
+        rebuilt = struct.pack("<4sII", b"glTF", 2, 12 + 8 + len(new_json) + len(remaining))
+        rebuilt += struct.pack("<II", len(new_json), 0x4E4F534A) + new_json + remaining
+        file_path.write_bytes(rebuilt)
+        return True
+    except Exception as error:
+        print(f"[ImageMetaHub-Save] Warning: could not embed GLB metadata: {error}")
+        return False
+
+
+def _next_path(filename_prefix: str, extension: str) -> Tuple[Path, str]:
+    if folder_paths is None:
+        raise RuntimeError("ComfyUI folder_paths is unavailable")
+    output_root = folder_paths.get_output_directory()
+    full_folder, filename, counter, subfolder, _prefix = folder_paths.get_save_image_path(filename_prefix, output_root)
+    candidate = Path(full_folder) / f"{filename}_{counter:05}_.{extension}"
+    while candidate.exists():
+        counter += 1
+        candidate = Path(full_folder) / f"{filename}_{counter:05}_.{extension}"
+    return candidate, subfolder
+
+
+def _build_metadata(
+    prompt: Any,
+    extra_pnginfo: Any,
+    unique_id: Any,
+    tags: str,
+    notes: str,
+    project_name: str,
+    generation_time_override: Optional[float],
+) -> Dict[str, Any]:
+    workflow_json = utils.get_workflow_json(extra_pnginfo)
+    prompt_data = prompt if isinstance(prompt, dict) else workflow_json.get("prompt", {})
+    if not isinstance(prompt_data, dict):
+        prompt_data = {}
+    workflow_json = utils.ensure_prompt_in_workflow(workflow_json, prompt_data)
+    save_node_id = str(unique_id) if unique_id is not None else None
+    utils.ensure_metahub_save_node(
+        workflow_json,
+        save_node_id,
+        class_type="MetaHubSave3DModel",
+        display_name="MetaHub Save 3D Model",
+    )
+    extracted, _missing = WorkflowExtractor(prompt_data).extract(save_node_id=save_node_id)
+    loras = extracted.get("lora_list") or utils.extract_loras_from_workflow(workflow_json)
+    model_name = extracted.get("model_name") or ""
+    steps = int(extracted.get("steps") or 0)
+    elapsed = time.time() - generation_time_override if generation_time_override and generation_time_override > 0 else 0.0
+    generation_time_ms = int(elapsed * 1000) if elapsed > 0 else None
+    gpu = utils.collect_gpu_metrics()
+    versions = utils.collect_version_info()
+    fields = ["seed", "steps", "cfg", "sampler_name", "scheduler", "model_name", "positive", "negative", "denoise", "vae_name"]
+    sources = utils.build_metadata_sources({}, extracted, fields)
+    params = {
+        "positive": extracted.get("positive") or "",
+        "negative": extracted.get("negative") or "",
+        "seed": int(extracted.get("seed") or 0),
+        "steps": steps,
+        "cfg": float(extracted.get("cfg") or 0.0),
+        "sampler": extracted.get("sampler_name") or "",
+        "scheduler": extracted.get("scheduler") or "",
+        "model_name": model_name,
+        "model_hash": utils.calculate_model_hash(model_name, model_type="checkpoint") if model_name else "",
+        "vae_name": extracted.get("vae_name") or "",
+        "denoise": float(extracted.get("denoise") or 1.0),
+        "width": 0,
+        "height": 0,
+        "lora_list": loras,
+        "user_tags": tags,
+        "notes": notes,
+        "project_name": project_name,
+        "generation_time": elapsed,
+        "generation_time_ms": generation_time_ms,
+        "steps_per_second": round(steps / elapsed, 2) if steps > 0 and elapsed > 0 else None,
+        "vram_peak_mb": gpu.get("vram_peak_mb"),
+        "gpu_device": gpu.get("gpu_device"),
+        "comfyui_version": versions.get("comfyui_version"),
+        "torch_version": versions.get("torch_version"),
+        "python_version": versions.get("python_version"),
+        "metadata_status": utils.build_metadata_status(sources),
+        "metadata_sources": sources,
+        "imh_attribution": utils.extract_workflow_attribution(workflow_json, save_node_id),
+        "source_image": extracted.get("source_image"),
+        "generation_type": extracted.get("generation_type"),
+    }
+    result = utils.build_imh_metadata(params, workflow_json)
+    result["schema_version"] = 1
+    result["media_type"] = "model3d"
+    return result
+
+
+def _write_sidecar(model_path: Path, metadata: Dict[str, Any]) -> Path:
+    sidecar_path = Path(str(model_path) + ".imagemetahub.json")
+    sidecar_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+    return sidecar_path
+
+
+def _source_node_class(prompt: Any, unique_id: Any) -> Optional[str]:
+    if not isinstance(prompt, dict) or unique_id is None:
+        return None
+    save_node = prompt.get(str(unique_id)) or prompt.get(unique_id)
+    if not isinstance(save_node, dict):
+        return None
+    model_input = (save_node.get("inputs") or {}).get("model_3d")
+    if not isinstance(model_input, (list, tuple)) or not model_input:
+        return None
+    upstream = prompt.get(str(model_input[0])) or prompt.get(model_input[0])
+    if not isinstance(upstream, dict):
+        return None
+    class_type = upstream.get("class_type")
+    return str(class_type) if class_type else None
+
+
+class MetaHubSave3DModel:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model_3d": (ANY_3D, {"tooltip": "ComfyUI MESH or File3D model"}),
+                "filename_prefix": ("STRING", {"default": "3d/ComfyUI"}),
+            },
+            "optional": {
+                "tags": ("STRING", {"default": ""}),
+                "notes": ("STRING", {"default": "", "multiline": True}),
+                "project_name": ("STRING", {"default": ""}),
+                "generation_time_override": ("FLOAT", {"default": None, "forceInput": True}),
+            },
+            "hidden": {
+                "prompt": "PROMPT",
+                "extra_pnginfo": "EXTRA_PNGINFO",
+                "unique_id": "UNIQUE_ID",
+            },
+        }
+
+    RETURN_TYPES = ()
+    FUNCTION = "save_model"
+    OUTPUT_NODE = True
+    CATEGORY = "3d/save"
+    DESCRIPTION = "Save a 3D model with Image MetaHub generation metadata"
+
+    def save_model(
+        self,
+        model_3d: Any,
+        filename_prefix: str = "3d/ComfyUI",
+        tags: str = "",
+        notes: str = "",
+        project_name: str = "",
+        generation_time_override: Optional[float] = None,
+        prompt: Any = None,
+        extra_pnginfo: Any = None,
+        unique_id: Any = None,
+    ) -> Dict[str, Any]:
+        metadata = None if getattr(args, "disable_metadata", False) else _build_metadata(
+            prompt,
+            extra_pnginfo,
+            unique_id,
+            tags,
+            notes,
+            project_name,
+            generation_time_override,
+        )
+        results = []
+        saved_paths: list[str] = []
+        source_node_class = _source_node_class(prompt, unique_id)
+
+        if hasattr(model_3d, "save_to"):
+            extension = str(getattr(model_3d, "format", "glb") or "glb").lower().lstrip(".")
+            if extension not in SUPPORTED_FORMATS:
+                raise ValueError(f"Unsupported 3D format: {extension}")
+            output_path, subfolder = _next_path(filename_prefix, extension)
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            model_3d.save_to(str(output_path))
+            model_info = {"format": extension, "sourceNodeClass": source_node_class or type(model_3d).__name__}
+            payload = dict(metadata or {})
+            payload["model_3d"] = model_info
+            if metadata:
+                if extension == "glb":
+                    _inject_glb_metadata(output_path, payload)
+                _write_sidecar(output_path, payload)
+            results.append({"filename": output_path.name, "subfolder": subfolder, "type": "output"})
+            saved_paths.append(str(output_path))
+        elif hasattr(model_3d, "vertices") and hasattr(model_3d, "faces"):
+            batch_size = int(model_3d.vertices.shape[0])
+            for index in range(batch_size):
+                vertices, faces, colors, uvs, texture = _mesh_batch_item(model_3d, index)
+                output_path, subfolder = _next_path(filename_prefix, "glb")
+                payload = dict(metadata or {})
+                model_info = _write_glb(
+                    output_path,
+                    vertices,
+                    faces,
+                    None,
+                    vertex_colors=colors,
+                    uvs=uvs,
+                    texture=texture,
+                    unlit=bool(getattr(model_3d, "unlit", False)),
+                )
+                payload["model_3d"] = model_info
+                model_info["sourceNodeClass"] = source_node_class or type(model_3d).__name__
+                if metadata:
+                    _inject_glb_metadata(output_path, payload)
+                    _write_sidecar(output_path, payload)
+                results.append({"filename": output_path.name, "subfolder": subfolder, "type": "output"})
+                saved_paths.append(str(output_path))
+        else:
+            raise TypeError("MetaHub Save 3D Model expected a MESH or File3D value")
+
+        return {"ui": {"3d": results, "imagemetahub_files": saved_paths}}
+
+
+NODE_CLASS_MAPPINGS = {"MetaHubSave3DModel": MetaHubSave3DModel}
+NODE_DISPLAY_NAME_MAPPINGS = {"MetaHubSave3DModel": "MetaHub Save 3D Model"}

--- a/metahub_save_3d_node.py
+++ b/metahub_save_3d_node.py
@@ -120,10 +120,14 @@ def _write_glb(
         uv_array = None
 
     texture_bytes = b""
+    texture_has_transparency = False
     if texture is not None:
         texture_array = _tensor_numpy(texture, np.float32)
         texture_array = np.clip(texture_array * 255.0, 0, 255).astype(np.uint8)
         if texture_array.ndim == 3 and texture_array.shape[-1] in (3, 4):
+            texture_has_transparency = (
+                texture_array.shape[-1] == 4 and bool(np.any(texture_array[..., 3] < 255))
+            )
             buffer = BytesIO()
             Image.fromarray(texture_array, mode="RGBA" if texture_array.shape[-1] == 4 else "RGB").save(buffer, "PNG")
             texture_bytes = buffer.getvalue()
@@ -195,14 +199,20 @@ def _write_glb(
         gltf["images"] = [{"bufferView": texture_view, "mimeType": "image/png"}]
         gltf["samplers"] = [{"magFilter": 9729, "minFilter": 9729, "wrapS": 33071, "wrapT": 33071}]
         gltf["textures"] = [{"source": 0, "sampler": 0}]
-        materials.append({
+        material = {
             "pbrMetallicRoughness": {
                 "baseColorTexture": {"index": 0, "texCoord": 0},
                 "metallicFactor": 0.0,
                 "roughnessFactor": 1.0,
             },
             "doubleSided": True,
-        })
+        }
+        if texture_has_transparency:
+            material["alphaMode"] = "BLEND"
+        if unlit:
+            material["extensions"] = {"KHR_materials_unlit": {}}
+            gltf["extensionsUsed"] = ["KHR_materials_unlit"]
+        materials.append(material)
         primitive["material"] = 0
     elif unlit:
         materials.append({

--- a/metahub_save_3d_node.py
+++ b/metahub_save_3d_node.py
@@ -313,6 +313,7 @@ def _build_metadata(
     loras = extracted.get("lora_list") or utils.extract_loras_from_workflow(workflow_json)
     model_name = extracted.get("model_name") or ""
     steps = int(extracted.get("steps") or 0)
+    denoise = extracted.get("denoise")
     elapsed = time.time() - generation_time_override if generation_time_override and generation_time_override > 0 else 0.0
     generation_time_ms = int(elapsed * 1000) if elapsed > 0 else None
     gpu = utils.collect_gpu_metrics()
@@ -330,7 +331,7 @@ def _build_metadata(
         "model_name": model_name,
         "model_hash": utils.calculate_model_hash(model_name, model_type="checkpoint") if model_name else "",
         "vae_name": extracted.get("vae_name") or "",
-        "denoise": float(extracted.get("denoise") or 1.0),
+        "denoise": float(denoise) if denoise is not None else 1.0,
         "width": 0,
         "height": 0,
         "lora_list": loras,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "imagemetahub-comfyui-save"
 description = "Official companion node for Image MetaHub. Saves A1111/Civitai-compatible parameters plus extended Image MetaHub metadata (workflow JSON, SHA256 model hashes, VRAM peak/total, GPU device, generation time, and steps/sec) for reproducibility and benchmarking."
-version = "1.1.9"
+version = "1.2.0"
 license = {file = "LICENSE"} 
 # classifiers = [
 #     # For OS-independent nodes (works on all operating systems)

--- a/tests/test_metadata_utils.py
+++ b/tests/test_metadata_utils.py
@@ -334,7 +334,7 @@ def test_extract_workflow_attribution_from_node_properties():
 
     assert attribution["token"] == "imhcrt_br_creator_workflow_v1_random"
     assert attribution["source"] == "metahub_save_node"
-    assert attribution["node_version"] == "1.1.9"
+    assert attribution["node_version"] == "1.2.0"
 
 
 def test_build_imh_metadata_includes_attribution_without_a1111_parameters():

--- a/tests/test_metahub_save_3d_node.py
+++ b/tests/test_metahub_save_3d_node.py
@@ -92,6 +92,31 @@ def test_texture_without_usable_uvs_is_not_reported_as_embedded(tmp_path):
     assert "textures" not in gltf
 
 
+def test_build_metadata_preserves_zero_denoise(monkeypatch):
+    class FakeExtractor:
+        def __init__(self, _prompt):
+            pass
+
+        def extract(self, save_node_id):
+            assert save_node_id == "3"
+            return {"denoise": 0.0, "lora_list": []}, set()
+
+    monkeypatch.setattr(node3d, "WorkflowExtractor", FakeExtractor)
+    monkeypatch.setattr(node3d.utils, "get_workflow_json", lambda _info: {})
+    monkeypatch.setattr(node3d.utils, "ensure_prompt_in_workflow", lambda workflow, _prompt: workflow)
+    monkeypatch.setattr(node3d.utils, "ensure_metahub_save_node", lambda *args, **kwargs: None)
+    monkeypatch.setattr(node3d.utils, "extract_loras_from_workflow", lambda _workflow: [])
+    monkeypatch.setattr(node3d.utils, "collect_gpu_metrics", lambda: {})
+    monkeypatch.setattr(node3d.utils, "collect_version_info", lambda: {})
+    monkeypatch.setattr(node3d.utils, "build_metadata_sources", lambda *args: {})
+    monkeypatch.setattr(node3d.utils, "extract_workflow_attribution", lambda *args: {})
+    monkeypatch.setattr(node3d.utils, "build_imh_metadata", lambda params, _workflow: params)
+
+    metadata = node3d._build_metadata({}, {}, "3", "", "", "", None)
+
+    assert metadata["denoise"] == 0.0
+
+
 def test_textured_unlit_mesh_preserves_unlit_and_transparency(tmp_path):
     mesh = _mesh()
     mesh.unlit = True

--- a/tests/test_metahub_save_3d_node.py
+++ b/tests/test_metahub_save_3d_node.py
@@ -76,6 +76,22 @@ def test_disable_metadata_writes_model_without_sidecar_or_extras(tmp_path, monke
     assert "extras" not in _read_glb_json(model_path)["asset"]
 
 
+def test_texture_without_usable_uvs_is_not_reported_as_embedded(tmp_path):
+    mesh = _mesh()
+
+    geometry = node3d._write_glb(
+        tmp_path / "no-uvs.glb",
+        mesh.vertices[0],
+        mesh.faces[0],
+        {},
+        texture=mesh.texture[0],
+    )
+    gltf = _read_glb_json(tmp_path / "no-uvs.glb")
+
+    assert geometry["hasTextures"] is False
+    assert "textures" not in gltf
+
+
 def test_file3d_preserves_received_format_and_writes_sidecar(tmp_path, monkeypatch):
     class FakeFile3D:
         format = "obj"

--- a/tests/test_metahub_save_3d_node.py
+++ b/tests/test_metahub_save_3d_node.py
@@ -1,0 +1,123 @@
+import json
+import struct
+from types import SimpleNamespace
+
+import numpy as np
+
+import metahub_save_3d_node as node3d
+
+
+class FakeFolderPaths:
+    def __init__(self, output_dir):
+        self.output_dir = output_dir
+
+    def get_output_directory(self):
+        return str(self.output_dir)
+
+    def get_save_image_path(self, _prefix, _output_root):
+        folder = self.output_dir / "3d"
+        folder.mkdir(parents=True, exist_ok=True)
+        return str(folder), "ComfyUI", 1, "3d", "3d/ComfyUI"
+
+
+def _mesh(with_optional_data=True):
+    vertices = np.array([[[0, 0, 0], [1, 0, 0], [0, 1, 0]]], dtype=np.float32)
+    faces = np.array([[[0, 1, 2]]], dtype=np.int64)
+    return SimpleNamespace(
+        vertices=vertices,
+        faces=faces,
+        vertex_colors=np.array([[[1, 0, 0], [0, 1, 0], [0, 0, 1]]], dtype=np.float32) if with_optional_data else None,
+        uvs=np.array([[[0, 0], [1, 0], [0, 1]]], dtype=np.float32) if with_optional_data else None,
+        texture=np.ones((1, 2, 2, 3), dtype=np.float32) if with_optional_data else None,
+        unlit=False,
+    )
+
+
+def _read_glb_json(path):
+    data = path.read_bytes()
+    assert data[:4] == b"glTF"
+    json_length, json_type = struct.unpack_from("<II", data, 12)
+    assert json_type == 0x4E4F534A
+    return json.loads(data[20:20 + json_length].rstrip(b" \x00"))
+
+
+def test_mesh_writes_glb_sidecar_and_embedded_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(node3d, "folder_paths", FakeFolderPaths(tmp_path))
+    monkeypatch.setattr(node3d.args, "disable_metadata", False)
+    monkeypatch.setattr(node3d, "_build_metadata", lambda *args, **kwargs: {
+        "schema_version": 1,
+        "media_type": "model3d",
+        "prompt": "synthetic prompt",
+        "workflow": {"nodes": []},
+        "prompt_api": {},
+    })
+
+    result = node3d.MetaHubSave3DModel().save_model(_mesh())
+
+    model_path = tmp_path / "3d" / result["ui"]["3d"][0]["filename"]
+    sidecar_path = model_path.with_name(model_path.name + ".imagemetahub.json")
+    sidecar = json.loads(sidecar_path.read_text(encoding="utf-8"))
+    embedded = _read_glb_json(model_path)["asset"]["extras"]["imagemetahub_data"]
+    assert sidecar == embedded
+    assert sidecar["model_3d"]["vertexCount"] == 3
+    assert sidecar["model_3d"]["faceCount"] == 1
+    assert sidecar["model_3d"]["hasTextures"] is True
+    assert result["ui"]["imagemetahub_files"] == [str(model_path)]
+
+
+def test_disable_metadata_writes_model_without_sidecar_or_extras(tmp_path, monkeypatch):
+    monkeypatch.setattr(node3d, "folder_paths", FakeFolderPaths(tmp_path))
+    monkeypatch.setattr(node3d.args, "disable_metadata", True)
+
+    result = node3d.MetaHubSave3DModel().save_model(_mesh(with_optional_data=False))
+
+    model_path = tmp_path / "3d" / result["ui"]["3d"][0]["filename"]
+    assert not model_path.with_name(model_path.name + ".imagemetahub.json").exists()
+    assert "extras" not in _read_glb_json(model_path)["asset"]
+
+
+def test_file3d_preserves_received_format_and_writes_sidecar(tmp_path, monkeypatch):
+    class FakeFile3D:
+        format = "obj"
+
+        def save_to(self, path):
+            with open(path, "wb") as handle:
+                handle.write(b"o synthetic\n")
+
+    monkeypatch.setattr(node3d, "folder_paths", FakeFolderPaths(tmp_path))
+    monkeypatch.setattr(node3d.args, "disable_metadata", False)
+    monkeypatch.setattr(node3d, "_build_metadata", lambda *args, **kwargs: {
+        "schema_version": 1,
+        "media_type": "model3d",
+        "workflow": {},
+        "prompt_api": {},
+    })
+
+    result = node3d.MetaHubSave3DModel().save_model(FakeFile3D())
+
+    model_path = tmp_path / "3d" / result["ui"]["3d"][0]["filename"]
+    assert model_path.suffix == ".obj"
+    assert model_path.read_bytes() == b"o synthetic\n"
+    assert model_path.with_name(model_path.name + ".imagemetahub.json").exists()
+
+
+def test_source_node_class_is_read_from_prompt_link():
+    prompt = {
+        "7": {"class_type": "SyntheticMeshGenerator", "inputs": {}},
+        "8": {"class_type": "MetaHubSave3DModel", "inputs": {"model_3d": ["7", 0]}},
+    }
+
+    assert node3d._source_node_class(prompt, "8") == "SyntheticMeshGenerator"
+
+
+def test_mesh_batch_increments_filenames(tmp_path, monkeypatch):
+    mesh = _mesh(with_optional_data=False)
+    mesh.vertices = np.repeat(mesh.vertices, 2, axis=0)
+    mesh.faces = np.repeat(mesh.faces, 2, axis=0)
+    monkeypatch.setattr(node3d, "folder_paths", FakeFolderPaths(tmp_path))
+    monkeypatch.setattr(node3d.args, "disable_metadata", True)
+
+    result = node3d.MetaHubSave3DModel().save_model(mesh)
+
+    filenames = [item["filename"] for item in result["ui"]["3d"]]
+    assert filenames == ["ComfyUI_00001_.glb", "ComfyUI_00002_.glb"]

--- a/tests/test_metahub_save_3d_node.py
+++ b/tests/test_metahub_save_3d_node.py
@@ -92,6 +92,29 @@ def test_texture_without_usable_uvs_is_not_reported_as_embedded(tmp_path):
     assert "textures" not in gltf
 
 
+def test_textured_unlit_mesh_preserves_unlit_and_transparency(tmp_path):
+    mesh = _mesh()
+    mesh.unlit = True
+    mesh.texture = np.ones((1, 2, 2, 4), dtype=np.float32)
+    mesh.texture[0, 0, 0, 3] = 0.25
+
+    node3d._write_glb(
+        tmp_path / "textured-unlit.glb",
+        mesh.vertices[0],
+        mesh.faces[0],
+        {},
+        uvs=mesh.uvs[0],
+        texture=mesh.texture[0],
+        unlit=mesh.unlit,
+    )
+    gltf = _read_glb_json(tmp_path / "textured-unlit.glb")
+    material = gltf["materials"][0]
+
+    assert material["extensions"] == {"KHR_materials_unlit": {}}
+    assert gltf["extensionsUsed"] == ["KHR_materials_unlit"]
+    assert material["alphaMode"] == "BLEND"
+
+
 def test_file3d_preserves_received_format_and_writes_sidecar(tmp_path, monkeypatch):
     class FakeFile3D:
         format = "obj"

--- a/tests/test_workflow_extractor.py
+++ b/tests/test_workflow_extractor.py
@@ -55,6 +55,20 @@ def test_workflow_extractor_basic_prompt():
     assert data["vae_name"] == "model.safetensors"
 
 
+def test_workflow_extractor_traces_sampler_from_model_3d_input():
+    prompt = {
+        "1": {"class_type": "KSampler", "inputs": {"seed": 111}},
+        "2": {"class_type": "KSampler", "inputs": {"seed": 222}},
+        "3": {"class_type": "SyntheticMeshGenerator", "inputs": {"samples": ["2", 0]}},
+        "4": {"class_type": "MetaHubSave3DModel", "inputs": {"model_3d": ["3", 0]}},
+    }
+
+    extractor = WorkflowExtractor(prompt)
+    data, _missing = extractor.extract(save_node_id="4")
+
+    assert data["seed"] == 222
+
+
 def test_workflow_extractor_lora_detection():
     prompt = {
         "1": {

--- a/tests/test_workflow_extractor.py
+++ b/tests/test_workflow_extractor.py
@@ -69,6 +69,34 @@ def test_workflow_extractor_traces_sampler_from_model_3d_input():
     assert data["seed"] == 222
 
 
+def test_workflow_extractor_traces_source_image_from_model_3d_input():
+    prompt = {
+        "1": {
+            "class_type": "LoadImage",
+            "inputs": {"image": "inputs/source.png"},
+        },
+        "2": {
+            "class_type": "SyntheticImageToMesh",
+            "inputs": {"image": ["1", 0]},
+        },
+        "3": {
+            "class_type": "MetaHubSave3DModel",
+            "inputs": {"model_3d": ["2", 0]},
+        },
+    }
+
+    extractor = WorkflowExtractor(prompt)
+    data, _missing = extractor.extract(save_node_id="3")
+
+    assert data["generation_type"] == "image2model3d"
+    assert data["source_image"] == {
+        "fileName": "source.png",
+        "relativePath": "inputs/source.png",
+        "nodeId": "1",
+        "nodeType": "LoadImage",
+    }
+
+
 def test_workflow_extractor_lora_detection():
     prompt = {
         "1": {

--- a/tests/test_workflow_extractor.py
+++ b/tests/test_workflow_extractor.py
@@ -69,6 +69,21 @@ def test_workflow_extractor_traces_sampler_from_model_3d_input():
     assert data["seed"] == 222
 
 
+def test_workflow_extractor_traces_vae_from_model_3d_input():
+    prompt = {
+        "1": {"class_type": "CheckpointLoaderSimple", "inputs": {"ckpt_name": "model.safetensors"}},
+        "2": {"class_type": "KSampler", "inputs": {"model": ["1", 0]}},
+        "3": {"class_type": "VAEDecode", "inputs": {"samples": ["2", 0], "vae": ["1", 2]}},
+        "4": {"class_type": "SyntheticMeshGenerator", "inputs": {"images": ["3", 0]}},
+        "5": {"class_type": "MetaHubSave3DModel", "inputs": {"model_3d": ["4", 0]}},
+    }
+
+    extractor = WorkflowExtractor(prompt)
+    data, _missing = extractor.extract(save_node_id="5")
+
+    assert data["vae_name"] == "model.safetensors"
+
+
 def test_workflow_extractor_traces_source_image_from_model_3d_input():
     prompt = {
         "1": {

--- a/workflow_extractor.py
+++ b/workflow_extractor.py
@@ -137,12 +137,13 @@ class WorkflowExtractor:
         if save_node_id:
             save_node = self._get_node(save_node_id)
             if save_node:
-                images_conn = save_node.get("inputs", {}).get("images")
-                start_node_id = self._get_connection_node_id(images_conn)
-                if start_node_id:
-                    sampler_id = self._find_sampler_from_images_source(start_node_id)
-                    if sampler_id:
-                        return sampler_id
+                inputs = save_node.get("inputs", {})
+                for input_name in ("images", "model_3d"):
+                    start_node_id = self._get_connection_node_id(inputs.get(input_name))
+                    if start_node_id:
+                        sampler_id = self._find_sampler_from_images_source(start_node_id)
+                        if sampler_id:
+                            return sampler_id
 
         return sampler_nodes[0]
 

--- a/workflow_extractor.py
+++ b/workflow_extractor.py
@@ -494,14 +494,18 @@ class WorkflowExtractor:
         save_node = self._get_node(save_node_id)
         if not save_node:
             return None
-        images_conn = save_node.get("inputs", {}).get("images")
-        start_node_id = self._get_connection_node_id(images_conn)
-        if not start_node_id:
-            return None
-        return self._bfs_upstream(
-            [start_node_id],
-            lambda n: self._class_type(n) in self.VAE_DECODE_NODES,
-        )
+        inputs = save_node.get("inputs", {})
+        for input_name in ("images", "model_3d"):
+            start_node_id = self._get_connection_node_id(inputs.get(input_name))
+            if not start_node_id:
+                continue
+            vae_decode_id = self._bfs_upstream(
+                [start_node_id],
+                lambda n: self._class_type(n) in self.VAE_DECODE_NODES,
+            )
+            if vae_decode_id:
+                return vae_decode_id
+        return None
 
     def _find_nodes_by_type(self, types: List[str]) -> List[str]:
         matched = []

--- a/workflow_extractor.py
+++ b/workflow_extractor.py
@@ -123,7 +123,7 @@ class WorkflowExtractor:
         elif has_lora_nodes:
             missing.add("loras")
 
-        lineage = self.extract_lineage(sampler_node_id)
+        lineage = self.extract_model_3d_lineage(save_node_id) or self.extract_lineage(sampler_node_id)
         if lineage:
             data.update(lineage)
 
@@ -412,6 +412,58 @@ class WorkflowExtractor:
             "generation_type": generation_type,
             "source_image": source_image,
         }
+
+    def extract_model_3d_lineage(self, save_node_id: Optional[str]) -> Dict[str, Any]:
+        if not save_node_id:
+            return {}
+
+        save_node = self._get_node(save_node_id)
+        if not save_node:
+            return {}
+
+        class_type = self._class_type(save_node).lower().replace("_", "").replace(" ", "")
+        if "save3d" not in class_type and "saveglb" not in class_type:
+            return {}
+
+        inputs = save_node.get("inputs", {})
+        model_conn = inputs.get("model_3d") or inputs.get("mesh") or inputs.get("model")
+        start_node_id = self._get_connection_node_id(model_conn)
+        if not start_node_id:
+            return {}
+
+        queue = [start_node_id]
+        visited: Set[str] = set()
+        while queue:
+            current_id = queue.pop(0)
+            if current_id in visited:
+                continue
+            visited.add(current_id)
+
+            current = self._get_node(current_id)
+            if not current:
+                continue
+
+            current_type = self._class_type(current)
+            if current_type in self.LOAD_IMAGE_NODES or current_type.lower() == "loadimage":
+                image_value = current.get("inputs", {}).get("image")
+                if isinstance(image_value, str) and image_value.strip():
+                    normalized = image_value.replace("\\", "/")
+                    return {
+                        "generation_type": "image2model3d",
+                        "source_image": {
+                            "fileName": normalized.split("/")[-1],
+                            "relativePath": normalized,
+                            "nodeId": current_id,
+                            "nodeType": current_type,
+                        },
+                    }
+
+            for input_value in current.get("inputs", {}).values():
+                upstream_id = self._get_connection_node_id(input_value)
+                if upstream_id and upstream_id not in visited:
+                    queue.append(upstream_id)
+
+        return {}
 
     def _find_sampler_from_images_source(self, start_node_id: str) -> Optional[str]:
         start_node = self._get_node(start_node_id)


### PR DESCRIPTION
## Summary

- add the public `MetaHubSave3DModel` node under `3d/save`
- accept legacy MESH and modern File3D GLB, GLTF, OBJ, FBX, and STL values
- save MESH batches as GLB while preserving UVs, vertex colors, textures, and bounds metadata
- preserve File3D input formats and return `ui.3d` for ComfyUI's native preview
- write schema v1 Image MetaHub sidecars for every supported format and embed the same payload in GLB
- honor `--disable-metadata` and register saved files with the existing Image MetaHub CTA

## Why

The companion package previously saved images and video only. ComfyUI 3D workflows need an equivalent output node that preserves generation parameters, complete workflow data, telemetry, tags, notes, and project information for Image MetaHub.

## Impact

Generated 3D assets can be saved directly from ComfyUI and indexed by Image MetaHub with the same metadata contract used by the existing companion nodes. Older ComfyUI installations retain a functional MESH-to-GLB fallback.

## Validation

- `python -B -m pytest tests/test_metahub_save_3d_node.py -q`
- 5 targeted tests passed for MESH, optional attributes, File3D preservation, counters, sidecars, GLB embedding, source-node attribution, and `--disable-metadata`

Image MetaHub app support: [Image-MetaHub PR #505](https://github.com/LuqP2/Image-MetaHub/pull/505).
